### PR TITLE
Fix test

### DIFF
--- a/app/templates/_index.js
+++ b/app/templates/_index.js
@@ -1,5 +1,3 @@
-const {} = require('@bitliner/parsly');
-
 const {list, rating, text, domain, country, language, date, html, cheerio} = require('@bitliner/parsly');
 
 

--- a/app/templates/_test.js
+++ b/app/templates/_test.js
@@ -2,18 +2,11 @@
 'use strict';
 
 let expect = require('chai').expect;
-let Parser = require('../');
+let parser = require('../');
 let HtmlParserTester = require('@bitliner/html-parser-test');
 let TestConf = require('./test.conf');
 
 describe('<%= htmlParserName %>-html-parser', function() {
-    let parser;
-
-    beforeEach(function() {
-        parser = new Parser({
-            api: require('@bitliner/parser-api'),
-        });
-    });
 
     describe('parse()', function() {
         TestConf.forEach(function(configuration, index) {
@@ -34,18 +27,4 @@ describe('<%= htmlParserName %>-html-parser', function() {
         });
     });
 
-    // it('getNextPages() should extract...', function() {
-    //     let htmlContent, nextPages;
-    //     let url, expectedNextLink;
-    //     url = '';
-    //     expectedNextLink = '';
-    //     htmlContent =
-    //     fs.readFileSync(path.resolve(__dirname, './data/page.html'), {
-    //         encoding: 'utf-8'
-    //     });
-    //     nextPages = Parser.getNextPages(htmlContent, url);
-
-    //     expect(nextPages).to.have.length(1);
-    //     expect(nextPages).to.include(expectedNextLink);
-    // });
 });


### PR DESCRIPTION
Fix test error due to a wrong parser initialization and remove a useless require of `@bitliner/parsly` in `index.js` template.